### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Pylint
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/n1kdo/rotator-controller-controller/security/code-scanning/1](https://github.com/n1kdo/rotator-controller-controller/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs Pylint (with no steps that require write access), the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). The best practice is to set it at the workflow level unless a job requires different permissions. The change should be made near the top of the file, after the `name` and before `on`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
